### PR TITLE
Zip creation on demand

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,39 @@
         <url>https://github.com/s-match/s-match-utils/issues</url>
     </issueManagement>
 
+	
+	<profiles>
+		<profile>
+			<id>makeZip</id>
+			<build>
+			<plugins>			
+				<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+
+                        <configuration>
+                            <finalName>s-match-${project.version}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <attach>true</attach>
+                            <descriptors>
+                                <descriptor>src/main/assembly/s-match-assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+	            </plugin>	            
+            </plugins>
+            </build>			
+		</profile>
+	</profiles>
+	
     <dependencies>
         <!-- spring -->
         <dependency>
@@ -253,29 +286,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>all</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-
-                        <configuration>
-                            <finalName>s-match-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <attach>false</attach>
-                            <descriptors>
-                                <descriptor>src/main/assembly/s-match-assembly.xml</descriptor>
-                            </descriptors>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+            </plugin>            
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,30 +30,30 @@
 		<profile>
 			<id>makeZip</id>
 			<build>
-			<plugins>			
-				<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>all</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-
-                        <configuration>
-                            <finalName>s-match-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <attach>true</attach>
-                            <descriptors>
-                                <descriptor>src/main/assembly/s-match-assembly.xml</descriptor>
-                            </descriptors>
-                        </configuration>
-                    </execution>
-                </executions>
-	            </plugin>	            
-            </plugins>
+				<plugins>			
+					<plugin>
+		                <groupId>org.apache.maven.plugins</groupId>
+		                <artifactId>maven-assembly-plugin</artifactId>
+		                <executions>
+		                    <execution>
+		                        <id>all</id>
+		                        <phase>package</phase>
+		                        <goals>
+		                            <goal>single</goal>
+		                        </goals>
+		
+		                        <configuration>
+		                            <finalName>s-match-${project.version}</finalName>
+		                            <appendAssemblyId>false</appendAssemblyId>
+		                            <attach>true</attach>
+		                            <descriptors>
+		                                <descriptor>src/main/assembly/s-match-assembly.xml</descriptor>
+		                            </descriptors>
+		                        </configuration>
+		                    </execution>
+		                </executions>
+		            </plugin>	            
+	            </plugins>
             </build>			
 		</profile>
 	</profiles>


### PR DESCRIPTION
As S-Match Utils grows larger, building process may be get slow when testing. This pull request speeds up building time by making zip creation available only on explicit request:

- added `makeZip` Maven profile
- now zip creation is off by default, to invoke it use `-PmakeZip`
- now zip is also copied to local repo

(the diff with master seems a bit odd,  maybe at line 289 is adding an unnecessary `</plugin>` )