### PR TITLE
allsteps command

### DIFF
--- a/src/main/java/it/unitn/disi/smatch/CLI.java
+++ b/src/main/java/it/unitn/disi/smatch/CLI.java
@@ -43,6 +43,12 @@ public class CLI {
     /**
      * @since 2.0.0
      */
+    public static final String VERBOSE_CMD_LINE_KEY = "-v";
+
+    
+    /**
+     * @since 2.0.0
+     */
     public static final String CMD_ALL_STEPS = "allsteps";
     
     // usage string
@@ -58,7 +64,8 @@ public class CLI {
             "\n" +
             " Options: \n" +
             " -config=file.xml                           read configuration from file.xml instead of default s-match.xml\n" +
-            "                                            use -Dkey=value to supply values to ${key} placeholders in the config file";
+            "                                            use -Dkey=value to supply values to ${key} placeholders in the config file\n" +
+            " -v                                         turn verbose mode on\n";    
 
     /**
      * Provides command line interface to the match manager.
@@ -71,11 +78,17 @@ public class CLI {
     public static void main(String[] args) throws IOException, DISIException, ClassNotFoundException {
         // initialize property file
         String configFileName = null;
+        boolean verbose = false;
+        
         ArrayList<String> cleanArgs = new ArrayList<>();
         for (String arg : args) {
             if (arg.startsWith(CONFIG_FILE_CMD_LINE_KEY)) {
                 configFileName = arg.substring(CONFIG_FILE_CMD_LINE_KEY.length());
-                log.info("Using config file: {}", configFileName);
+
+                System.out.println("Using config file: " + configFileName);
+            } else if (arg.equals(VERBOSE_CMD_LINE_KEY)) {
+                verbose = true;
+                System.out.println("Verbose mode ON");
             } else {
                 cleanArgs.add(arg);
             }
@@ -201,7 +214,16 @@ public class CLI {
                             mm.offline(ctxSource1);
                             IContext ctxSource2 = (IContext) mm.loadContext(inputFile2);
                             mm.offline(ctxSource2);
-                            IContextMapping<INode> result = mm.online(ctxSource1, ctxSource2); 
+                            IContextMapping<INode> result = mm.online(ctxSource1, ctxSource2);
+                            try {
+                                IContextMapping<INode> mapOutput = mm.filterMapping(result);
+                            } catch (SMatchException ex){
+                                System.out.println("INFO: No filtering was performed (too see why, run with flag " + VERBOSE_CMD_LINE_KEY + ")");
+                                if (verbose){
+                                    System.out.println("Reason:");
+                                    ex.printStackTrace();
+                                }
+                            }
                             mm.renderMapping(result, outputFile);
                         } else {
                             System.out.println("To preprocess a mapping, use context loaders that support IContextLoader ");

--- a/src/main/java/it/unitn/disi/smatch/CLI.java
+++ b/src/main/java/it/unitn/disi/smatch/CLI.java
@@ -41,12 +41,64 @@ public class CLI {
     public static final String CONFIG_FILE_CMD_LINE_KEY = "-config=";
 
     /**
-     * @since 2.0.0
+     * Create cached WordNet files for fast matching:
+     * 
+     * <pre> 
+     * {@code wntoflat <jwnlConfig> <files...>}
+     * </pre>
      */
-    public static final String VERBOSE_CMD_LINE_KEY = "-v";
+    public static final String CMD_WN_TO_FLAT = "wntoflat";    
 
-    
     /**
+     * Read input file and write it into output file:
+     * 
+     * <pre>
+     * {@code convert <input> <output>}
+     * </pre>
+     * 
+     * Read source, target and input mapping, and write the output mapping:
+     * 
+     * <pre>
+     * {@code convert <source> <target> <input> <output>}
+     * </pre>
+     */
+    public static final String CMD_CONVERT = "convert";    
+               
+    /**
+     * Read input file, preprocess it and write it into output file:
+     * 
+     * <pre>
+     * {@code offline <input> <output> }
+     * </pre>    
+     */
+    public static final String CMD_OFFLINE = "offline";
+                 
+    /** 
+     * Read source and target files, run matching and write the output file:
+     * 
+     * <pre>
+     * {@code online <source> <target> <output> }
+     * </pre>    
+     */
+    public static final String CMD_ONLINE = "online";
+           
+    /**
+     * Read source and target files, input mapping, run filtering and write the output mapping:
+     * 
+     * <pre>
+     * {@code filter <source> <target> <input> <output>}
+     * </pre>    
+     */
+    public static final String CMD_FILTER = "filter";
+    
+    
+    /** 
+     * Read source and target files, run all steps from 1 to 4 and write the output mapping:
+     * 
+     * <pre>
+     * {@code  allsteps <source> <target> <output>  }
+     * </pre>
+     * 
      * @since 2.0.0
      */
     public static final String CMD_ALL_STEPS = "allsteps";
@@ -64,8 +116,7 @@ public class CLI {
             "\n" +
             " Options: \n" +
             " -config=file.xml                           read configuration from file.xml instead of default s-match.xml\n" +
-            "                                            use -Dkey=value to supply values to ${key} placeholders in the config file\n" +
-            " -v                                         turn verbose mode on\n";    
+            "                                            use -Dkey=value to supply values to ${key} placeholders in the config file\n";    
 
     /**
      * Provides command line interface to the match manager.
@@ -78,17 +129,12 @@ public class CLI {
     public static void main(String[] args) throws IOException, DISIException, ClassNotFoundException {
         // initialize property file
         String configFileName = null;
-        boolean verbose = false;
         
         ArrayList<String> cleanArgs = new ArrayList<>();
         for (String arg : args) {
             if (arg.startsWith(CONFIG_FILE_CMD_LINE_KEY)) {
                 configFileName = arg.substring(CONFIG_FILE_CMD_LINE_KEY.length());
-
                 System.out.println("Using config file: " + configFileName);
-            } else if (arg.equals(VERBOSE_CMD_LINE_KEY)) {
-                verbose = true;
-                System.out.println("Verbose mode ON");
             } else {
                 cleanArgs.add(arg);
             }
@@ -103,7 +149,7 @@ public class CLI {
             IMatchManager mm;
 
             switch (args[0]) {
-                case "wntoflat":
+                case CMD_WN_TO_FLAT:
                     if (9 < args.length) {
                         CLI.convertWordNetToFlat(
                                 args[1],
@@ -120,7 +166,7 @@ public class CLI {
                         log.error("Not enough arguments for wntoflat command.");
                     }
                     break;
-                case "convert":
+                case CMD_CONVERT:
                     mm = createMatchManager(configFileName);
                     if (2 < args.length) {
                         if (3 == args.length) {
@@ -147,7 +193,7 @@ public class CLI {
                         log.error("Not enough arguments for convert command.");
                     }
                     break;
-                case "offline":
+                case CMD_OFFLINE:
                     mm = createMatchManager(configFileName);
                     if (2 < args.length) {
                         String inputFile = args[1];
@@ -163,7 +209,7 @@ public class CLI {
                         log.error("Not enough arguments for offline command.");
                     }
                     break;
-                case "online":
+                case CMD_ONLINE:
                     mm = createMatchManager(configFileName);
                     if (3 < args.length) {
                         String sourceFile = args[1];
@@ -181,7 +227,7 @@ public class CLI {
                         log.error("Not enough arguments for online command.");
                     }
                     break;
-                case "filter":
+                case CMD_FILTER:
                     mm = createMatchManager(configFileName);
                     if (4 < args.length) {
                         String sourceFile = args[1];
@@ -199,7 +245,7 @@ public class CLI {
                             log.warn("To filter a mapping, use context loaders supporting IContextLoader.");
                         }
                     } else {
-                        log.error("Not enough arguments for mappingFilter command.");
+                        log.error("Not enough arguments for filter command.");
                     }
                     break;
                 case CMD_ALL_STEPS:
@@ -218,18 +264,15 @@ public class CLI {
                             try {
                                 IContextMapping<INode> mapOutput = mm.filterMapping(result);
                             } catch (SMatchException ex){
-                                System.out.println("INFO: No filtering was performed (too see why, run with flag " + VERBOSE_CMD_LINE_KEY + ")");
-                                if (verbose){
-                                    System.out.println("Reason:");
-                                    ex.printStackTrace();
-                                }
+                                log.info("No filtering was performed (too see why, set logging at DEBUG level)");                                                               
+                                log.debug("Reason:\n", ex);                                
                             }
                             mm.renderMapping(result, outputFile);
                         } else {
-                            System.out.println("To preprocess a mapping, use context loaders that support IContextLoader ");
+                            log.error("To preprocess a mapping, use context loaders that support IContextLoader");
                         }
                     } else {
-                        System.out.println("Not enough arguments for allsteps command.");
+                        log.error("Not enough arguments for allsteps command.");
                     }
                     break;
                 default:

--- a/src/main/java/it/unitn/disi/smatch/CLI.java
+++ b/src/main/java/it/unitn/disi/smatch/CLI.java
@@ -40,6 +40,11 @@ public class CLI {
     // config file command line key
     public static final String CONFIG_FILE_CMD_LINE_KEY = "-config=";
 
+    /**
+     * @since 2.0.0
+     */
+    public static final String CMD_ALL_STEPS = "allsteps";
+    
     // usage string
     private static final String USAGE = "Usage: MatchManager <command> <arguments> [options]\n" +
             " Commands: \n" +
@@ -49,6 +54,7 @@ public class CLI {
             " offline <input> <output>                   read input file, preprocess it and write it into output file\n" +
             " online <source> <target> <output>          read source and target files, run matching and write the output file\n" +
             " filter <source> <target> <input> <output>  read source and target files, input mapping, run filtering and write the output mapping\n" +
+            " allsteps <source> <target> <output>        read source and target files, run all steps from 1 to 4 and write the output mapping\n" +            
             "\n" +
             " Options: \n" +
             " -config=file.xml                           read configuration from file.xml instead of default s-match.xml\n" +
@@ -181,6 +187,27 @@ public class CLI {
                         }
                     } else {
                         log.error("Not enough arguments for mappingFilter command.");
+                    }
+                    break;
+                case CMD_ALL_STEPS:
+                    mm = createMatchManager(configFileName);
+                    if (3 < args.length) {
+                        String inputFile1 = args[1];
+                        String inputFile2 = args[2];
+                        String outputFile = args[3];
+                        
+                        if (mm.getContextLoader() instanceof IContextLoader) {
+                            IContext ctxSource1 = (IContext) mm.loadContext(inputFile1);
+                            mm.offline(ctxSource1);
+                            IContext ctxSource2 = (IContext) mm.loadContext(inputFile2);
+                            mm.offline(ctxSource2);
+                            IContextMapping<INode> result = mm.online(ctxSource1, ctxSource2); 
+                            mm.renderMapping(result, outputFile);
+                        } else {
+                            System.out.println("To preprocess a mapping, use context loaders that support IContextLoader ");
+                        }
+                    } else {
+                        System.out.println("Not enough arguments for allsteps command.");
                     }
                     break;
                 default:

--- a/src/test/java/it/unitn/disi/smatch/test/CliTest.java
+++ b/src/test/java/it/unitn/disi/smatch/test/CliTest.java
@@ -21,7 +21,6 @@ import it.unitn.disi.smatch.CLI;
 /**
  * @since 2.0.0
  * @author <a rel="author" href="http://davidleoni.it/">David Leoni</a>
- *
  */
 public class CliTest {
 
@@ -84,14 +83,5 @@ public class CliTest {
         
         CLI.main(new String[]{"666", "999"});
     }
-    
-    /**
-     * @since 2.0.0
-     */
-    @Test
-    public void testVerbose() throws ClassNotFoundException, IOException, DISIException{
-                
-        CLI.main(new String[]{CLI.VERBOSE_CMD_LINE_KEY});               
-    }
-    
+        
 }

--- a/src/test/java/it/unitn/disi/smatch/test/CliTest.java
+++ b/src/test/java/it/unitn/disi/smatch/test/CliTest.java
@@ -23,9 +23,9 @@ import it.unitn.disi.smatch.CLI;
  * @author <a rel="author" href="http://davidleoni.it/">David Leoni</a>
  *
  */
-public class TestCLI {
+public class CliTest {
 
-    public static final Logger log = Logger.getLogger(TestCLI.class);
+    public static final Logger log = Logger.getLogger(CliTest.class);
     
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/src/test/java/it/unitn/disi/smatch/test/TestCLI.java
+++ b/src/test/java/it/unitn/disi/smatch/test/TestCLI.java
@@ -64,4 +64,34 @@ public class TestCLI {
         
         assertFalse(output.exists());                
     }
+    
+    /**
+     * @since 2.0.0
+     */
+    @Test
+    public void testNoArgs() throws ClassNotFoundException, IOException, DISIException{
+        
+        CLI.main(new String[]{});
+    }
+    
+    /**
+     * @since 2.0.0
+     */
+    @Test
+    public void testUnrecognizedCommand() throws ClassNotFoundException, IOException, DISIException{
+        
+        CLI.main(new String[]{"666"});
+        
+        CLI.main(new String[]{"666", "999"});
+    }
+    
+    /**
+     * @since 2.0.0
+     */
+    @Test
+    public void testVerbose() throws ClassNotFoundException, IOException, DISIException{
+                
+        CLI.main(new String[]{CLI.VERBOSE_CMD_LINE_KEY});               
+    }
+    
 }

--- a/src/test/java/it/unitn/disi/smatch/test/TestCLI.java
+++ b/src/test/java/it/unitn/disi/smatch/test/TestCLI.java
@@ -1,0 +1,67 @@
+package it.unitn.disi.smatch.test;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+import org.junit.Rule;
+
+import org.junit.rules.TemporaryFolder;
+
+import it.unitn.disi.common.DISIException;
+import it.unitn.disi.smatch.CLI;
+
+
+/**
+ * @since 2.0.0
+ * @author <a rel="author" href="http://davidleoni.it/">David Leoni</a>
+ *
+ */
+public class TestCLI {
+
+    public static final Logger log = Logger.getLogger(TestCLI.class);
+    
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * @since 2.0.0
+     */
+    @Test
+    public void testAllSteps() throws ClassNotFoundException, IOException, DISIException {
+                
+       File output = new File(folder.getRoot(), UUID.randomUUID().toString());                      
+        
+        CLI.main(new String[]{
+                CLI.CMD_ALL_STEPS,
+                "src/main/resources/test-data/cw/c.xml",
+                "src/main/resources/test-data/cw/w.xml",
+                output.getAbsolutePath()
+                });
+        log.debug("Output mapping is " + output.getAbsolutePath());
+        assertTrue(output.exists());                
+    }
+    
+    /**
+     * @since 2.0.0
+     */
+    @Test
+    public void testAllStepsMissingArg() throws ClassNotFoundException, IOException, DISIException {
+                
+       File output = new File(folder.getRoot(), UUID.randomUUID().toString());
+        
+        CLI.main(new String[]{
+                CLI.CMD_ALL_STEPS,
+                "src/main/resources/test-data/cw/c.xml",
+                "src/main/resources/test-data/cw/w.xml"
+                });
+        
+        assertFalse(output.exists());                
+    }
+}


### PR DESCRIPTION
S-Match CLI for a full match requires several runs to perform all needed steps, so each run needlessly spends time redoing initialization. This is a problem for batch processing. Ideally, for this scenario in the long term we would need a demon running as a service. As a quick improvement, with this pull request we just added the CLI command `allsteps`:

```
allsteps <source> <target> <output>    
Read source and target files, run all steps from 1 to 4 and write the output mapping
```
We also added some tests and a verbose flag `-v`: currently doesn't do much, but will be useful for future improvements
