### PR TITLE
Fixes #19 - spsm config should be sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,14 @@
         </dependency>
 
         <dependency>
+            <scope>test</scope>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+        </dependency>
+
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
@@ -247,6 +255,16 @@
             </resource>
         </resources>
         <plugins>
+        
+	        <plugin>
+	            <groupId>org.apache.maven.plugins</groupId>
+	            <artifactId>maven-surefire-plugin</artifactId>
+	            <configuration>
+	            	<!--  because xmls load  ../conf/wn31resource  -->
+	                <workingDirectory>src/main/resources/bin</workingDirectory>
+	            </configuration>
+	        </plugin>
+        
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>appassembler-maven-plugin</artifactId>

--- a/src/main/resources/conf/s-match-spsm-function.xml
+++ b/src/main/resources/conf/s-match-spsm-function.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <import resource="s-match.xml"/>
+    <import resource="s-match-synchronous.xml"/>
 
     <bean id="contextLoader" class="it.unitn.disi.smatch.loaders.context.StringFunctionLoader"/>
 

--- a/src/main/resources/conf/s-match-spsm.xml
+++ b/src/main/resources/conf/s-match-spsm.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
-    <import resource="s-match.xml"/>
+    <import resource="s-match-synchronous.xml"/>
  
     <bean id="treeMatcher" class="it.unitn.disi.smatch.matchers.structure.tree.spsm.SPSMTreeMatcher">
         <constructor-arg name="nodeMatcher" ref="nodeMatcher"/>

--- a/src/test/java/it/unitn/disi/smatch/test/CliTest.java
+++ b/src/test/java/it/unitn/disi/smatch/test/CliTest.java
@@ -19,6 +19,11 @@ import it.unitn.disi.smatch.CLI;
 
 
 /**
+ * 
+ * <p>
+ * <b>Note</b>: working dir during testing is {@code src/main/resources/bin}
+ * </p>
+ * 
  * @since 2.0.0
  * @author <a rel="author" href="http://davidleoni.it/">David Leoni</a>
  */
@@ -39,8 +44,8 @@ public class CliTest {
         
         CLI.main(new String[]{
                 CLI.CMD_ALL_STEPS,
-                "src/main/resources/test-data/cw/c.xml",
-                "src/main/resources/test-data/cw/w.xml",
+                "../test-data/cw/c.xml",
+                "../test-data/cw/w.xml",
                 output.getAbsolutePath()
                 });
         log.debug("Output mapping is " + output.getAbsolutePath());

--- a/src/test/java/it/unitn/disi/smatch/test/ConfigTest.java
+++ b/src/test/java/it/unitn/disi/smatch/test/ConfigTest.java
@@ -1,0 +1,169 @@
+package it.unitn.disi.smatch.test;
+
+import static org.junit.Assert.assertTrue;
+import it.unitn.disi.smatch.IMatchManager;
+import it.unitn.disi.smatch.MatchManager;
+import it.unitn.disi.smatch.SMatchException;
+import it.unitn.disi.smatch.data.mappings.IContextMapping;
+import it.unitn.disi.smatch.data.mappings.IMappingElement;
+import it.unitn.disi.smatch.data.trees.IContext;
+import it.unitn.disi.smatch.data.trees.INode;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Attempts to load several configs to check if anything explodes
+ * Config loading is done with API calls.
+ * <p>
+ * <b>NOTE</b>: running dir during testing is {@code src/main/resources/bin}
+ * </p>
+ * 
+ * @since 2.0.0
+ * @author <a rel="author" href="http://davidleoni.it/">David Leoni</a>
+ */
+public class ConfigTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ConfigTest.class);
+
+    /**
+     * 
+     * @since 2.0.0
+     */
+    private IContextMapping<INode> runPipeline(String configFilename) throws SMatchException {
+        log.info("****  CONFIG: " + configFilename);
+        log.info("Creating MatchManager...");
+
+        IMatchManager mm = MatchManager.getInstanceFromConfigFile("../conf/" + configFilename);
+
+        log.info("Creating source context...");
+        IContext s = mm.createContext();
+        INode sroot = s.createRoot("dog");
+        sroot.createChild("cat");
+        sroot.createChild("fish");
+
+        IContext t = mm.createContext();
+        INode troot = t.createRoot("dog");
+        troot.createChild("feline");
+        INode tfish = troot.createChild("fish");
+        tfish.createChild("carp");
+
+        IContextMapping<INode> result = mm.match(s, t);
+
+        log.info("Processing results...");
+        log.info("Printing matches:");
+        for (IMappingElement<INode> e : result) {
+            log.info(e.getSource()
+                      .nodeData()
+                      .getName() + "\t" + e.getRelation() + "\t" + e.getTarget()
+                                                                    .nodeData()
+                                                                    .getName());
+        }
+
+        result = mm.match(s, t);
+
+        log.info("Processing results...");
+        log.info("Printing matches:");
+        for (IMappingElement<INode> e : result) {
+            log.info(e.getSource()
+                      .nodeData()
+                      .getName() + "\t" + e.getRelation() + "\t" + e.getTarget()
+                                                                    .nodeData()
+                                                                    .getName());
+        }
+
+        log.info("Done");
+
+        return result;
+    }
+
+    /**
+     * Ignored because of Async.setProgress error in core:
+     * https://github.com/s-match/s-match-core/issues/13
+     * 
+     * @since 2.0.0
+     */
+    @Test
+    @Ignore
+    public void testDefault() throws SMatchException {
+
+        IContextMapping<INode> results = runPipeline("s-match.xml");
+
+        assertTrue(results.size() > 0);
+
+        // TODO need better check
+
+    }
+
+    /**
+     * 
+     * @since 2.0.0
+     */
+    @Test
+    public void testSynchronous() throws SMatchException {
+
+        IContextMapping<INode> results = runPipeline("s-match-synchronous.xml");
+
+        assertTrue(results.size() > 0);
+
+        // TODO need better check
+
+    }
+
+    /**
+     * Test case for <a href="https://github.com/s-match/s-match-core/issues/10"
+     * target="_blank"> #10 in core, async not working</a>
+     * 
+     * @throws SMatchException
+     * 
+     * @since 2.0.0
+     */
+    @Test
+    public void testSpsm() throws SMatchException {
+
+        IContextMapping<INode> results = runPipeline("s-match-spsm.xml");
+
+        assertTrue(results.size() > 0);
+
+        // TODO need better check
+
+    }
+
+    /**
+     * Test case for <a href="https://github.com/s-match/s-match-core/issues/10"
+     * target="_blank"> #10 in core, async not working</a>
+     * and also <a href="https://github.com/s-match/s-match-utils/issues/4"
+     * target="_blank"> #4 in utils, asymm not working</a>
+     * 
+     * @throws SMatchException
+     * 
+     * @since 2.0.0
+     */
+    @Test
+    public void testSpsmAsymmetric() throws SMatchException {
+
+        IContextMapping<INode> results = runPipeline("s-match-spsm-asymmetric.xml");
+
+        assertTrue(results.size() > 0);
+
+        // TODO need better check
+    }
+
+    /**
+     * 
+     * @since 2.0.0
+     */
+    @Test
+    public void testSpsmFunction() throws SMatchException {
+
+        IContextMapping<INode> results = runPipeline("s-match-spsm-function.xml");
+
+        assertTrue(results.size() > 0);
+
+        // TODO need better check
+
+    }
+
+}


### PR DESCRIPTION
- set spsm, spsm-asymmetric and spsm-function configs to use synchronous s-match
- set test maven execution dir to src/main/resources/bin because xmls load ../conf/wn31resource
- added ConfigTest for testing various configurations
    - ignored default config because of https://github.com/s-match/s-match-core/issues/13
    - uses dog fish test trees from https://github.com/s-match/s-match-spsm/issues/4